### PR TITLE
failed to build on macOS 10.15.7 with ffmpeg 4.3.1; libswresample not…

### DIFF
--- a/modules/FindFFMPEG.cmake
+++ b/modules/FindFFMPEG.cmake
@@ -106,6 +106,11 @@ FIND_LIBRARY(FFMPEG_swscale_LIBRARY swscale
   /usr/lib
 )
 
+FIND_LIBRARY(FFMPEG_swresample_LIBRARY swresample
+  /usr/local/lib
+  /usr/lib
+)
+
 FIND_LIBRARY(FFMPEG_z_LIBRARY z
   /usr/local/lib
   /usr/lib
@@ -127,6 +132,10 @@ IF(FFMPEG_INCLUDE_DIR)
         IF(FFMPEG_swscale_LIBRARY)
           LIST(APPEND FFMPEG_BASIC_LIBRARIES ${FFMPEG_swscale_LIBRARY})
         ENDIF(FFMPEG_swscale_LIBRARY)
+
+        IF(FFMPEG_swresample_LIBRARY)
+          LIST(APPEND FFMPEG_BASIC_LIBRARIES ${FFMPEG_swresample_LIBRARY})
+        ENDIF(FFMPEG_swresample_LIBRARY)
 
         SET(FFMPEG_LIBRARIES ${FFMPEG_BASIC_LIBRARIES})
 


### PR DESCRIPTION
… linked.

```
/usr/local/Cellar/cmake/3.19.4/bin/cmake -E cmake_link_script CMakeFiles/audiorw.dir/link.txt --verbose=1
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -Wall -Wextra -O3 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk -mmacosx-version-min=10.15 -dynamiclib -Wl,-headerpad_max_install_names -o libaudiorw.dylib -install_name @rpath/libaudiorw.dylib CMakeFiles/audiorw.dir/src/read.cpp.o CMakeFiles/audiorw.dir/src/write.cpp.o  /usr/local/lib/libavcodec.dylib /usr/local/lib/libavformat.dylib /usr/local/lib/libavutil.dylib /usr/local/lib/libswscale.dylib /usr/local/lib/libvorbis.dylib /usr/local/lib/libvorbisenc.dylib /usr/local/lib/libtheora.dylib /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/lib/libz.tbd
Undefined symbols for architecture x86_64:
  "_swr_alloc_set_opts", referenced from:
      audiorw::read(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double&, double, double) in read.cpp.o
      audiorw::write(std::__1::vector<std::__1::vector<double, std::__1::allocator<double> >, std::__1::allocator<std::__1::vector<double, std::__1::allocator<double> > > > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double) in write.cpp.o
  "_swr_convert", referenced from:
      audiorw::read(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double&, double, double) in read.cpp.o
      audiorw::write(std::__1::vector<std::__1::vector<double, std::__1::allocator<double> >, std::__1::allocator<std::__1::vector<double, std::__1::allocator<double> > > > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double) in write.cpp.o
  "_swr_free", referenced from:
      audiorw::read(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double&, double, double) in read.cpp.o
      audiorw::cleanup(AVCodecContext*, AVFormatContext*, SwrContext*, AVFrame*, AVPacket) in read.cpp.o
  "_swr_init", referenced from:
      audiorw::read(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double&, double, double) in read.cpp.o
      audiorw::write(std::__1::vector<std::__1::vector<double, std::__1::allocator<double> >, std::__1::allocator<std::__1::vector<double, std::__1::allocator<double> > > > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, double) in write.cpp.o
ld: symbol(s) not found for architecture x86_64
```

The link line does not include /usr/local/lib/libswresample.dylib

Fixed in cmake configuration.
